### PR TITLE
chore: onboard stepsecurity and apply security best practice

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,15 +28,20 @@ jobs:
   run_refund_tests_and_lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Update submodules
         run: git submodule update --init --recursive
         shell: bash
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e # v1.5.0
         with:
           version: nightly
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,11 +27,14 @@ permissions: read-all
 jobs:
   run_refund_tests_and_lint:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      - name: Harden the runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
-          egress-policy: audit
+          egress-policy: block
+          policy: global-allowed-endpoints-policy
 
       - name: Check out repository code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0


### PR DESCRIPTION
This pull request updates the CI workflow to improve security and reliability. The main changes include hardening the GitHub Actions runner, pinning action versions to specific commit SHAs, and updating permissions.

Security enhancements:

* Added a step to harden the GitHub Actions runner using the `step-security/harden-runner` action, which blocks unauthorized network egress and applies a global allowed endpoints policy.
* Set the `id-token: write` permission for the workflow, enabling secure use of OIDC tokens for authentication.

Dependency management:

* Replaced version tags with specific commit SHAs for `actions/checkout` and `foundry-rs/foundry-toolchain` to ensure reproducible builds and prevent supply chain attacks.