### PR TITLE
fix: security hardening - CEI pattern, over-withdrawal guard, debt settlement

### DIFF
--- a/src/RefundProtocol.sol
+++ b/src/RefundProtocol.sol
@@ -122,6 +122,8 @@ contract RefundProtocol is EIP712 {
             revert CallerNotAllowed();
         }
 
+        _settleDebt(msg.sender);
+
         uint256 recipientBalance = balances[payment.to];
 
         if (payment.amount > recipientBalance) {
@@ -298,6 +300,9 @@ contract RefundProtocol is EIP712 {
             if (withdrawalAmount > payment.amount) {
                 revert InvalidWithdrawalAmount(paymentID, withdrawalAmount);
             }
+            if (payment.withdrawnAmount + withdrawalAmount > payment.amount) {
+                revert InvalidWithdrawalAmount(paymentID, withdrawalAmount);
+            }
             if (payment.to != recipient) {
                 revert PaymentDoesNotBelongToRecipient();
             }
@@ -368,9 +373,10 @@ contract RefundProtocol is EIP712 {
         if (payment.refunded) {
             revert PaymentRefunded(paymentID);
         }
-        fiatToken.transfer(payment.refundTo, payment.amount);
 
         payments[paymentID].refunded = true;
+
+        fiatToken.transfer(payment.refundTo, payment.amount);
 
         emit Refund(paymentID, payment.refundTo, payment.amount);
     }

--- a/test/RefundProtocol.t.sol
+++ b/test/RefundProtocol.t.sol
@@ -372,6 +372,45 @@ contract RefundProtocolTest is Test {
         refundProtocol.earlyWithdrawByArbiter(paymentIDs, withdrawalAmounts, feeAmount, expiry, 0, receiver, v, r, s);
     }
 
+    function testEarlyWithdrawByArbiterCannotOverWithdrawPaymentWithSharedRecipientBalance() public {
+        vm.prank(arbiter);
+        refundProtocol.setLockupSeconds(receiver, 3600);
+
+        vm.startPrank(user);
+        refundProtocol.pay(receiver, 100, refundTo);
+        refundProtocol.pay(receiver, 100, refundTo);
+        vm.stopPrank();
+
+        uint256[] memory paymentIDs = new uint256[](1);
+        paymentIDs[0] = 0;
+        uint256[] memory withdrawalAmounts = new uint256[](1);
+        withdrawalAmounts[0] = 60;
+        uint256 feeAmount = 0;
+
+        (uint8 v1, bytes32 r1, bytes32 s1) =
+            _generateEarlyWithdrawalSignature(paymentIDs, withdrawalAmounts, feeAmount, expiry, 0, receiverPrivateKey);
+
+        vm.prank(arbiter);
+        refundProtocol.earlyWithdrawByArbiter(
+            paymentIDs, withdrawalAmounts, feeAmount, expiry, 0, receiver, v1, r1, s1
+        );
+
+        assertEq(refundProtocol.balances(receiver), 140);
+        assertEq(usdc.balanceOf(receiver), 60);
+
+        (uint8 v2, bytes32 r2, bytes32 s2) =
+            _generateEarlyWithdrawalSignature(paymentIDs, withdrawalAmounts, feeAmount, expiry, 1, receiverPrivateKey);
+
+        vm.prank(arbiter);
+        vm.expectRevert(abi.encodeWithSelector(RefundProtocol.InvalidWithdrawalAmount.selector, 0, 60));
+        refundProtocol.earlyWithdrawByArbiter(
+            paymentIDs, withdrawalAmounts, feeAmount, expiry, 1, receiver, v2, r2, s2
+        );
+
+        assertEq(refundProtocol.balances(receiver), 140);
+        assertEq(usdc.balanceOf(receiver), 60);
+    }
+
     function testEarlyWithdrawByArbiterInvalidFeeAmount() public {
         vm.prank(arbiter);
         refundProtocol.setLockupSeconds(receiver, 3600);


### PR DESCRIPTION
## Summary

This PR addresses three security vulnerabilities in RefundProtocol.sol:

### 1. Reentrancy risk in _executeRefund (fixes #12)

The \_executeRefund\ function performed an external \iatToken.transfer()\ call **before** updating \payments[paymentID].refunded = true\. This violates the checks-effects-interactions (CEI) pattern and opens a reentrancy vector if the token contract is malicious or upgradeable.

**Fix:** Move the state update (\payments[paymentID].refunded = true\) before the external transfer call.

### 2. Over-withdrawal via repeated earlyWithdrawByArbiter calls (fixes #11)

The \earlyWithdrawByArbiter\ function checks \withdrawalAmount > payment.amount\ per payment but never validates the **cumulative** withdrawn amount. An arbiter could call this function multiple times to withdraw more than the payment amount.

**Fix:** Add a cumulative check: \payment.withdrawnAmount + withdrawalAmount > payment.amount\.

### 3. Debt bypass in refundByRecipient (fixes #10)

The \efundByRecipient\ function does not call \_settleDebt(msg.sender)\ before checking and deducting the recipient's balance, unlike \withdraw()\ which does settle debt first. This means a recipient with outstanding debt can get a full refund without settling.

**Fix:** Add \_settleDebt(msg.sender)\ call before the balance check, matching the pattern in \withdraw()\.

## Testing

All 36 existing tests pass:

\\\
forge test -vv
# 36 passed, 0 failed, 0 skipped
\\\

## Changes

- \src/RefundProtocol.sol\: +7/-1 lines across three targeted fixes